### PR TITLE
fix: non-default image formats and video lengths

### DIFF
--- a/calliope/routes/thoth.py
+++ b/calliope/routes/thoth.py
@@ -76,8 +76,7 @@ async def thoth_story(
     if pagination.offset < num_frames:
         frames = await story.get_frames(
             offset=pagination.offset,
-            include_images=True,
-            include_videos=True,
+            include_media=True,
             max_frames=pagination.page_size
         )
     else:

--- a/calliope/routes/v1/story.py
+++ b/calliope/routes/v1/story.py
@@ -489,8 +489,8 @@ async def handle_existing_frames_request(
         "thoth_link": f"{base_url}thoth/story/{story.cuid}",
     }
 
-    frames = await story.get_frames(include_images=True)
-    # await prepare_frame_images(request_params, frames)
+    frames = await story.get_frames(include_media=True)
+    prepare_existing_frame_images(frames)
     frame_models = [frame.to_pydantic() for frame in frames]
 
     print(f"{story.created_for_sparrow_id=} {client_id=}")
@@ -622,6 +622,13 @@ async def prepare_frame_images(
             if is_google_cloud:
                 put_media_file(video.url)
 
+
+def prepare_existing_frame_images(
+    frames: List[StoryFrame],
+) -> None:
+    # Always return images in the original size and format.
+    for frame in frames:
+        frame.image = frame.source_image
 
 def shorten_title(title: Optional[str], max_length: int = 64) -> str:
     if not title:

--- a/calliope/storage/vector_manager.py
+++ b/calliope/storage/vector_manager.py
@@ -49,7 +49,7 @@ async def _get_story_frames(
         raise Exception(f"Unknown story: {story_cuid}")
 
     frames = await story.get_frames(
-        include_images=False, include_indexed_for_search=include_indexed_for_search
+        include_media=False, include_indexed_for_search=include_indexed_for_search
     )
     if frames:
         print(f"Need to index {len(frames)} frames of story {story.title}.")

--- a/calliope/strategies/fern.py
+++ b/calliope/strategies/fern.py
@@ -85,8 +85,7 @@ class FernStrategy(StoryStrategy):
     * Use gpt-neo as a "chaos and creativity engine".
     * Initialize the story with a conceipt and a cast of characters.
     * Stabilize character names and casting relations to people seen in input images.
-
-
+    * Optionally generate video.
     """
 
     strategy_name = "fern"
@@ -519,6 +518,12 @@ In Los Angeles, no Hollywood sign.
 
 Don't repeat things too often. If you just said in the previous page that it's raining or that there
 are cobblestone streets. You don't need to say it again now.
+
+Be specific about any and all movement in the video scene, including both character and camera
+movement. The scene will be a single take, so don't include any cuts or transitions. The video
+scene must begin with the illustration as its first frame, so start from there. Don't call for
+music or sound, as the video will be silent. Be detailed, but keep the scene description under
+1000 characters.
 
 A muse is here to help you by introducing less linear or expected aspects to the story.
 You can find their contribution in the <MUSE_TEXT>. If you see lively, imaginative, or

--- a/calliope/strategies/show_this_frame.py
+++ b/calliope/strategies/show_this_frame.py
@@ -60,7 +60,7 @@ class ShowThisFrameStrategy(StoryStrategy):
 
         text = parameters.input_text or ""
 
-        frames = await story.get_frames(max_frames=-1, include_images=True)
+        frames = await story.get_frames(max_frames=-1, include_media=True)
         last_frame = frames[0] if frames and len(frames) else None
         if not last_frame or last_frame.image != image or last_frame.text != text:
             # Create a new frame only if it differs from the story's last frame.

--- a/calliope/tables/story.py
+++ b/calliope/tables/story.py
@@ -177,9 +177,8 @@ class Story(Table):
         self,
         offset: int = 0,
         max_frames: int = 0,
-        include_images: bool = False,
+        include_media: bool = False,
         include_indexed_for_search: bool = True,
-        include_videos: bool = False,  # Added video support
     ) -> Sequence[StoryFrame]:
         """
         Gets the story's frames.
@@ -194,7 +193,7 @@ class Story(Table):
         """
         qs = (
             StoryFrame.objects(StoryFrame.image, StoryFrame.source_image, StoryFrame.video)
-            if include_images
+            if include_media
             else StoryFrame.objects()
         ).where(
             StoryFrame.story.id == self.id
@@ -215,7 +214,7 @@ class Story(Table):
             qs = qs.order_by(StoryFrame.number)
 
         frames = await qs.output(load_json=True).offset(offset).run()
-        if include_images:
+        if include_media:
             for frame in frames:
                 # This seems like a hack necessitated by a Piccolo quirk.
                 if frame.image and not frame.image.id:

--- a/calliope/templates/thoth_search.html
+++ b/calliope/templates/thoth_search.html
@@ -15,13 +15,15 @@
     {% for frame in results %}
     <div class="story-summary">
         <div class="summary-line">
-            Frame {{frame.number}} of story <a href="/thoth/story/{{frame.story.cuid}}{{'?meta=true' if show_metadata else ''}}&page={{1 + frame.number // story_page_size}}#f{{frame.number}}">"{{frame.story.title}}"</a>
+            Frame {{frame.number}} of story <a
+                href="/thoth/story/{{frame.story.cuid}}{{'?meta=true' if show_metadata else ''}}&page={{1 + frame.number // story_page_size}}#f{{frame.number}}">"{{frame.story.title[:200]}}"</a>
         </div>
         <div class="summary-line">
             Made by strategy {{frame.story.strategy_name}} on {{frame.date_created}}.
         </div>
         <div class="summary-links">
-            <a href="/clio/story/{{frame.story.slug if frame.story.slug else frame.story.cuid}}/{{frame.number + 1}}" class="clio-link" target="_blank">View in Clio</a>
+            <a href="/clio/story/{{frame.story.slug if frame.story.slug else frame.story.cuid}}/{{frame.number + 1}}"
+                class="clio-link" target="_blank">View in Clio</a>
         </div>
     </div>
     <div class="story-frame">
@@ -35,9 +37,7 @@
             <img src="/{{frame.source_image.url}}" alt="Frame {{frame.number}}" />
             {%- endif %}
         </div>
-        <div class="frame-text">
-            {{frame.text|safe}}
-        </div>
+        <div class="frame-text">{{frame.text|safe}}</div>
         {% if show_metadata %}
         <div class="frame-metadata">
             {{frame.pretty_metadata}}


### PR DESCRIPTION
# Overview

Multiple fixes:
* Enable Clio to show stories made with non-default image formats by delivering the original default image format.
* Parameterize video length.
* Truncate Runway prompt to 1000-character limit.
* Small styling fix in Thoth.