### PR TITLE
chore: add config dump script with API-key redaction

### DIFF
--- a/scripts/dump_config_to_sql.sh
+++ b/scripts/dump_config_to_sql.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Dump Calliope config tables to a SQL file (data-only, INSERT statements).
+# Redacts sparrow_config.keys (API credentials) via a Python post-processor.
+#
+# Output: scratch/calliope-config.sql
+#
+# Requires: the calliope-postgres-1 container to be running.
+set -euo pipefail
+
+CONTAINER="calliope-postgres-1"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RAW_OUT="$REPO_ROOT/scratch/calliope-config.raw.sql"
+FINAL_OUT="$REPO_ROOT/scratch/calliope-config.sql"
+
+mkdir -p "$REPO_ROOT/scratch"
+
+docker exec "$CONTAINER" pg_dump \
+    --data-only --inserts --no-owner --no-privileges \
+    -t prompt_template \
+    -t inference_model \
+    -t model_config \
+    -t strategy_config \
+    -t client_type_config \
+    -t sparrow_config \
+    -U postgres calliope > "$RAW_OUT"
+
+python3 "$REPO_ROOT/scripts/redact_sparrow_keys.py" "$RAW_OUT" "$FINAL_OUT"
+rm "$RAW_OUT"
+echo "Wrote $FINAL_OUT"

--- a/scripts/redact_sparrow_keys.py
+++ b/scripts/redact_sparrow_keys.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""Redact sparrow_config.keys (last column) in pg_dump INSERT output.
+
+Usage: redact_sparrow_keys.py INPUT.sql OUTPUT.sql
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+REDACTED_LITERAL = "'\"<<REDACTED>>\"'"
+SPARROW_INSERT = re.compile(r"INSERT INTO public\.sparrow_config VALUES ")
+
+
+def parse_values_list(s: str, open_paren: int) -> tuple[list[tuple[int, int]], int]:
+    """Walk forward from `(` at open_paren, return spans of each top-level value
+    and the index of the matching `)`. Handles SQL string `''` escapes.
+    """
+    assert s[open_paren] == "("
+    i = open_paren + 1
+    val_start = i
+    ranges: list[tuple[int, int]] = []
+    while True:
+        c = s[i]
+        if c == "'":
+            i += 1
+            while True:
+                if s[i] == "'":
+                    if i + 1 < len(s) and s[i + 1] == "'":
+                        i += 2
+                    else:
+                        i += 1
+                        break
+                else:
+                    i += 1
+        elif c == ",":
+            ranges.append((val_start, i))
+            i += 1
+            while s[i] == " ":
+                i += 1
+            val_start = i
+        elif c == ")":
+            ranges.append((val_start, i))
+            return ranges, i
+        else:
+            i += 1
+
+
+def redact(src: str) -> str:
+    out: list[str] = []
+    pos = 0
+    for m in SPARROW_INSERT.finditer(src):
+        open_paren = src.index("(", m.end())
+        ranges, _ = parse_values_list(src, open_paren)
+        last_start, last_end = ranges[-1]
+        out.append(src[pos:last_start])
+        out.append(REDACTED_LITERAL)
+        pos = last_end
+    out.append(src[pos:])
+    return "".join(out)
+
+
+def main() -> None:
+    src_path = Path(sys.argv[1])
+    dst_path = Path(sys.argv[2])
+    dst_path.write_text(redact(src_path.read_text()))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/dump_config_to_sql.sh` that runs `pg_dump --data-only --inserts` against the running `calliope-postgres-1` container for the six config tables (`prompt_template`, `inference_model`, `model_config`, `strategy_config`, `client_type_config`, `sparrow_config`).
- Adds `scripts/redact_sparrow_keys.py`, a small SQL-aware post-processor that replaces `sparrow_config.keys` (API credentials) with a `"<<REDACTED>>"` placeholder.
- Output lands at `scratch/calliope-config.sql` (gitignored) and is safe to share for offline analysis of the configuration data.

## Test plan
- [x] With docker compose up, run `./scripts/dump_config_to_sql.sh` and confirm it writes `scratch/calliope-config.sql` without errors.
- [x] `grep "INSERT INTO public.sparrow_config" scratch/calliope-config.sql` — every row should end with `'"<<REDACTED>>"'`.
- [x] `grep -E "sk-[A-Za-z0-9]{20,}|api_key.*[A-Za-z0-9]{20,}" scratch/calliope-config.sql` — should return nothing.
- [x] Row counts in the SQL should match Postgres for all six tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)