### PR TITLE
fix: Cloud Tasks worker dispatch + SPA cache (frames generate, images load)

### DIFF
--- a/calliope/app.py
+++ b/calliope/app.py
@@ -270,10 +270,16 @@ async def clio_root_redirect():
     return RedirectResponse("/clio/")
 
 
+# index.html references the content-hashed main.js (main.js?<hash>). It must
+# never be cached, or clients (notably iOS Safari / home-screen web apps) keep
+# loading a stale bundle across restarts and never pick up new deploys.
+INDEX_HTML_HEADERS = {"Cache-Control": "no-cache, must-revalidate"}
+
+
 # Root Clio route
 @app.get("/clio/", include_in_schema=False)
 async def serve_clio_root():
-    return FileResponse("static/clio/index.html")
+    return FileResponse("static/clio/index.html", headers=INDEX_HTML_HEADERS)
 
 
 # Define Clio routes more explicitly
@@ -296,5 +302,12 @@ async def serve_clio(path: str = ""):
     if os.path.isfile(static_path):
         return FileResponse(static_path)
 
+    # Don't fall back to index.html for asset-like paths (e.g. a relative media
+    # URL such as /clio/story/<slug>/media/foo.png). Returning index.html with a
+    # 200 makes a broken <img> "succeed" with HTML content, hiding the error;
+    # a 404 surfaces it instead.
+    if "." in path.rsplit("/", 1)[-1]:
+        raise HTTPException(status_code=404, detail="Not found")
+
     # For all other routes, serve index.html for client-side routing
-    return FileResponse("static/clio/index.html")
+    return FileResponse("static/clio/index.html", headers=INDEX_HTML_HEADERS)

--- a/calliope/routes/v2/tasks.py
+++ b/calliope/routes/v2/tasks.py
@@ -5,10 +5,11 @@ These endpoints receive HTTP requests from Google Cloud Tasks and
 execute the appropriate task handlers.
 """
 
-from fastapi import APIRouter, Request, HTTPException, Header, Depends
-import logging
 import json
-from typing import Optional, Dict, Any
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 
 from calliope.tasks import handlers
 from calliope.tasks.factory import configure_task_queue
@@ -83,15 +84,17 @@ async def process_task(
     # Get the payload from the request
     try:
         payload = await request.json()
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
         logger.error("Invalid JSON payload in task request")
-        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+        raise HTTPException(status_code=400, detail="Invalid JSON payload") from e
 
     # Log task information
     logger.info(f"Processing task of type '{task_type}' with metadata: {task_metadata}")
 
-    # Check if the task handler exists
-    handler_func = getattr(handlers, task_type, None)
+    # Check if the task handler exists. Resolve via the task-type registry
+    # rather than by attribute name, since the type ("add_frame") does not match
+    # the handler function name ("add_frame_task").
+    handler_func = handlers.get_task_handler(task_type)
     if not handler_func:
         logger.error(f"Unknown task type: {task_type}")
         raise HTTPException(status_code=404, detail=f"Unknown task type: {task_type}")
@@ -107,7 +110,7 @@ async def process_task(
         # Return the result
         return {"status": "success", "task_type": task_type, "result": result}
     except Exception as e:
-        logger.exception(f"Error processing task '{task_type}': {str(e)}")
+        logger.exception(f"Error processing task '{task_type}': {e!s}")
 
         # Determine if this is a retryable error
         # You could implement specific error types for different retry behaviors
@@ -119,13 +122,13 @@ async def process_task(
             # Set status code to trigger a retry in Cloud Tasks
             # 429 Too Many Requests or 503 Service Unavailable are typically used
             status_code = 503
-            detail = f"Retryable error processing task: {str(e)}"
+            detail = f"Retryable error processing task: {e!s}"
         else:
             # Non-retryable error
             status_code = 400
-            detail = f"Non-retryable error processing task: {str(e)}"
+            detail = f"Non-retryable error processing task: {e!s}"
 
-        raise HTTPException(status_code=status_code, detail=detail)
+        raise HTTPException(status_code=status_code, detail=detail) from e
 
 
 @router.get("/status/{task_id}")

--- a/calliope/tasks/handlers.py
+++ b/calliope/tasks/handlers.py
@@ -288,6 +288,21 @@ def is_development_environment() -> bool:
     return not is_production
 
 
+# Single source of truth mapping task type -> handler coroutine. Used both to
+# register handlers on the LocalTaskQueue and to dispatch Cloud Tasks callbacks
+# in the /v2/tasks/{task_type} route. (The route previously looked the handler
+# up by attribute name, which silently 404'd because the type "add_frame" does
+# not match the function name "add_frame_task".)
+TASK_HANDLERS: Dict[str, Any] = {
+    "add_frame": add_frame_task,
+}
+
+
+def get_task_handler(task_type: str) -> Any:
+    """Return the handler coroutine for a task type, or None if unknown."""
+    return TASK_HANDLERS.get(task_type)
+
+
 def register_handlers(task_queue: LocalTaskQueue):
     """
     Register all task handlers with the queue.
@@ -295,6 +310,7 @@ def register_handlers(task_queue: LocalTaskQueue):
     Args:
         task_queue: The LocalTaskQueue instance to register handlers with
     """
-    task_queue.register_handler("add_frame", add_frame_task)
+    for task_type, handler in TASK_HANDLERS.items():
+        task_queue.register_handler(task_type, handler)
 
     logger.info("Registered task handlers with the queue")

--- a/tests/test_task_dispatch.py
+++ b/tests/test_task_dispatch.py
@@ -1,0 +1,69 @@
+"""
+Regression test for the Cloud Tasks worker dispatch.
+
+The /v2/tasks/{task_type} endpoint previously resolved handlers with
+`getattr(handlers, task_type)`, which silently returned None because the task
+type "add_frame" does not match the handler function name "add_frame_task".
+Cloud Tasks callbacks 404'd ("Unknown task type: add_frame") and retried
+forever, so story/frame generation hung on a spinner. This path was never
+exercised until Cloud Tasks actually started running in production.
+
+These checks ensure the task-type registry is the single source of truth and
+that every type the queue can enqueue is resolvable by the worker.
+
+Run with:
+    PINECONE_API_KEY=dummy OPENAI_API_KEY=dummy uv run python tests/test_task_dispatch.py
+"""
+
+import calliope.tasks.handlers as handlers
+
+
+def test_every_registered_type_resolves():
+    """Each type in the registry resolves to its callable handler."""
+    assert handlers.TASK_HANDLERS, "expected at least one registered task type"
+    for task_type, handler in handlers.TASK_HANDLERS.items():
+        resolved = handlers.get_task_handler(task_type)
+        assert resolved is handler, f"{task_type} did not resolve to its handler"
+        assert callable(resolved), f"handler for {task_type} is not callable"
+
+
+def test_add_frame_is_registered():
+    """'add_frame' (the type enqueued by create_story / request_new_frame)
+    must resolve — this is the exact type that 404'd in production."""
+    handler = handlers.get_task_handler("add_frame")
+    assert handler is handlers.add_frame_task
+
+
+def test_unknown_type_returns_none():
+    assert handlers.get_task_handler("does_not_exist") is None
+
+
+def test_register_handlers_registers_all_types():
+    """register_handlers must register every type in the registry on a queue."""
+    registered = {}
+
+    class FakeQueue:
+        def register_handler(self, task_type, handler):
+            registered[task_type] = handler
+
+    handlers.register_handlers(FakeQueue())
+    assert registered == handlers.TASK_HANDLERS
+
+
+def test_worker_resolves_via_registry():
+    """The worker route resolves handlers through handlers.get_task_handler,
+    not by attribute name (the source of the original bug)."""
+    from calliope.routes.v2 import tasks as tasks_route
+
+    # The route module references the handlers module; confirm the lookup helper
+    # it relies on returns the add_frame handler.
+    assert tasks_route.handlers.get_task_handler("add_frame") is handlers.add_frame_task
+
+
+if __name__ == "__main__":
+    test_every_registered_type_resolves()
+    test_add_frame_is_registered()
+    test_unknown_type_returns_none()
+    test_register_handlers_registers_all_types()
+    test_worker_resolves_via_registry()
+    print("All task dispatch tests passed.")


### PR DESCRIPTION
Follow-up to #84. After enabling Cloud Tasks and deploying, two problems remained. Both root causes were found in the production Cloud Run logs.

## 1. Story creation hangs on a spinner

With Cloud Tasks now running, it calls back to `POST /v2/tasks/add_frame` — which returned **404 "Unknown task type: add_frame"**, so Cloud Tasks retried endlessly and no frame was ever produced (infinite spinner).

```
POST /v2/tasks/add_frame → 404 Not Found
calliope.routes.v2.tasks - ERROR - Unknown task type: add_frame
```

**Cause:** the worker resolved handlers with `getattr(handlers, task_type)`, but the task type `add_frame` doesn't match the function name `add_frame_task`, so it always resolved to `None`. This path was never exercised until Cloud Tasks actually ran (it previously fell back to in-process execution, which registers handlers by type correctly).

**Fix:** introduce a `TASK_HANDLERS` registry in `handlers.py` as the single source of truth, used by **both** `register_handlers` (local queue) and the worker route (`handlers.get_task_handler`). Added `tests/test_task_dispatch.py` to guard the type→handler contract.

## 2. Frame images invisible in the installed/home-screen app

Logs showed the device requesting carousel images at a **relative** path:

```
GET /clio/story/<slug>/media/....png → 200 (but this is index.html, not a PNG)   ❌
GET /media/....png                    → 200 image/png                              ✅ (thumbnails)
```

The device (iOS Safari, fullscreen home-screen app) was stuck on a **stale cached bundle** that built relative image URLs; the SPA fallback served those as `index.html` (200 HTML), so `<img>` loaded markup instead of a picture. The current deployed bundle builds correct absolute `/media/...` URLs, but `index.html` was served with **no `Cache-Control`**, so Safari never re-fetched the new bundle across restarts.

**Fix:**
- Serve `index.html` with `Cache-Control: no-cache, must-revalidate` so clients always pick up the current content-hashed `main.js`.
- Return **404** (not `index.html`) for asset-like SPA-fallback paths, so a bad media URL fails loudly instead of silently loading HTML.

> ⚠️ **One-time client action:** because the device won't revalidate the old `index.html`, the stale install must be reset once — on the iPhone, remove the home-screen app and re-add it (or clear website data for the site). After loading the new `index.html` once, the `no-cache` header keeps it current automatically.

## Changes
- `calliope/tasks/handlers.py` — `TASK_HANDLERS` registry + `get_task_handler`
- `calliope/routes/v2/tasks.py` — resolve handler via registry (also fixes pre-existing `B904`)
- `calliope/app.py` — `Cache-Control: no-cache` on `index.html`; 404 for asset-like fallback paths
- `tests/test_task_dispatch.py` (new) — dispatch regression test

## Testing
- Root-caused both from production logs (404 dispatch errors; relative media requests from the iPhone UA).
- `tests/test_task_dispatch.py` and `tests/test_gcp_queue.py` pass; ruff + ruff-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)