### PR TITLE
fix(tasks): patch Piccolo NULL-JSON crash blocking all frame generation

### DIFF
--- a/calliope/__init__.py
+++ b/calliope/__init__.py
@@ -1,0 +1,8 @@
+"""Calliope package."""
+
+# Apply third-party runtime patches as early as possible, before any database
+# query runs (the API server, the Cloud Tasks worker, and CLI tools all import
+# the calliope package first).
+from calliope.utils.piccolo_patches import apply_piccolo_patches
+
+apply_piccolo_patches()

--- a/calliope/utils/piccolo_patches.py
+++ b/calliope/utils/piccolo_patches.py
@@ -1,0 +1,51 @@
+"""
+Runtime patches for third-party library bugs.
+
+Kept in one place and applied once at import time (see calliope/__init__.py).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def apply_piccolo_patches() -> None:
+    """Make Piccolo's ``load_json`` tolerate NULL / already-deserialized values.
+
+    Piccolo 1.34's ``make_nested_object`` (used when a query loads nested related
+    rows, e.g. ``Table.objects(FK.all_related()).output(load_json=True)``) calls
+    ``encoding.load_json(value)`` for every JSON column of each nested row, with
+    no guard for ``None``. A nullable JSON column whose value is SQL ``NULL`` —
+    e.g. ``ModelConfig.model_parameters = JSONB(null=True)`` — therefore reaches
+    ``orjson.loads(None)`` and raises::
+
+        orjson.JSONDecodeError: Input must be bytes, bytearray, memoryview, or str
+
+    That broke ``get_strategy_config`` (and thus all frame generation) the moment
+    the Cloud Tasks worker actually started running. The unnested/top-level
+    code path guards ``None`` already; only the nested path is affected.
+
+    We wrap ``load_json`` so ``None`` and any already-deserialized value pass
+    through unchanged. This only adds behavior for inputs that previously raised,
+    so it cannot change any currently-working path. Patching the module
+    attribute is sufficient because ``make_nested_object`` calls it as
+    ``encoding.load_json(...)`` (resolved at call time).
+    """
+    from piccolo.utils import encoding
+
+    if getattr(encoding.load_json, "_calliope_null_safe", False):
+        return
+
+    original_load_json = encoding.load_json
+
+    def null_safe_load_json(data):
+        if data is None:
+            return None
+        if not isinstance(data, (str, bytes, bytearray, memoryview)):
+            # Already deserialized (dict / list / number / bool): return as-is.
+            return data
+        return original_load_json(data)
+
+    null_safe_load_json._calliope_null_safe = True  # type: ignore[attr-defined]
+    encoding.load_json = null_safe_load_json
+    logger.info("Applied Piccolo load_json NULL-safety patch")

--- a/tests/test_piccolo_patches.py
+++ b/tests/test_piccolo_patches.py
@@ -1,0 +1,57 @@
+"""
+Regression test for the Piccolo NULL-JSON crash that broke frame generation.
+
+Piccolo 1.34's make_nested_object calls encoding.load_json(value) for each JSON
+column of a nested related row with no None guard, so a nullable JSON column
+(e.g. ModelConfig.model_parameters = JSONB(null=True)) whose value is NULL
+raised orjson.JSONDecodeError. That blew up get_strategy_config (and thus all
+frame generation) once the Cloud Tasks worker started running.
+
+Importing `calliope` applies the null-safety patch (calliope/__init__.py).
+
+Run with:
+    PINECONE_API_KEY=dummy OPENAI_API_KEY=dummy uv run python tests/test_piccolo_patches.py
+"""
+
+from piccolo.columns import JSONB, Varchar
+from piccolo.table import Table
+from piccolo.utils import encoding
+from piccolo.utils.objects import make_nested_object
+
+import calliope  # noqa: F401  (import applies the Piccolo patch)
+
+
+class _StrategyConfigStub(Table):
+    name = Varchar()
+    params = JSONB(null=True)
+
+
+def test_load_json_none_is_safe():
+    assert encoding.load_json(None) is None
+
+
+def test_load_json_still_parses_strings():
+    assert encoding.load_json('{"a": 1}') == {"a": 1}
+
+
+def test_load_json_passes_through_already_parsed():
+    assert encoding.load_json({"a": 1}) == {"a": 1}
+
+
+def test_make_nested_object_tolerates_null_json_column():
+    """The exact failure mode: a NULL nullable-JSON column in a loaded row."""
+    obj = make_nested_object(
+        {"name": "lavender", "params": None},
+        _StrategyConfigStub,
+        load_json=True,
+    )
+    assert obj.params is None
+    assert obj.name == "lavender"
+
+
+if __name__ == "__main__":
+    test_load_json_none_is_safe()
+    test_load_json_still_parses_strings()
+    test_load_json_passes_through_already_parsed()
+    test_make_nested_object_tolerates_null_json_column()
+    print("All Piccolo patch tests passed.")


### PR DESCRIPTION
After #85 deployed, Cloud Tasks dispatch works (the `add_frame` task runs and moves to `recent_tasks`), but **every story stays at `frame_count: 0`** — no frame is ever produced. Found in the worker logs:

```
orjson.JSONDecodeError: Input must be bytes, bytearray, memoryview, or str
  add_frame_task → get_sparrow_story_parameters_and_keys
  → get_strategy_config → StrategyConfig.objects(... all_related()).output(load_json=True)
  → piccolo make_nested_object → encoding.load_json(value)
```

## Root cause
Piccolo 1.34's `make_nested_object` (used when a query loads nested related rows) calls `encoding.load_json(value)` for **every JSON column of each nested row, with no `None` guard**. A nullable JSON column whose value is SQL `NULL` — e.g. `ModelConfig.model_parameters = JSONB(null=True)` — reaches `orjson.loads(None)` and raises. Loading the `lavender` strategy config (with its related model configs) hit exactly this.

It was masked until now because the worker never actually executed while Cloud Tasks was misconfigured; it most likely regressed in the #82 dependency upgrade. It affects **every** `.objects(FK.all_related()).output(load_json=True)` query with a NULL nested JSON column (config loading, story frames, fern, tamarisk, …).

## Fix
Wrap `encoding.load_json` once, at the chokepoint, to pass through `None` and already-deserialized values instead of crashing — rather than editing each call site or migrating data. It only adds behavior for inputs that previously *raised*, so it cannot change any currently-working path. Applied at package import (`calliope/__init__.py`) so the API server, the Cloud Tasks worker, and CLI tools all get it.

## Changes
- `calliope/utils/piccolo_patches.py` (new) — `apply_piccolo_patches()` null-safety shim
- `calliope/__init__.py` — apply on import
- `tests/test_piccolo_patches.py` (new) — reproduces the crash and verifies the fix (incl. `make_nested_object` with a NULL JSON column)

## Testing
- Confirmed baseline `load_json(None)` raises `JSONDecodeError`; with the patch it returns `None` and `make_nested_object({...,"params":None}, T, load_json=True)` succeeds.
- Root-caused directly from the production worker traceback.

After merge + deploy, `add_frame` should produce frames and stories should populate. I can watch the logs to confirm `frame_count` goes > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)