### PR TITLE
fix(thoth): use new Starlette TemplateResponse(request, name, ...) signature

### DIFF
--- a/calliope/routes/thoth.py
+++ b/calliope/routes/thoth.py
@@ -1,15 +1,14 @@
 from datetime import datetime
-from typing import cast, Optional, Sequence
+from typing import Optional, Sequence, cast
 
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from markupsafe import Markup
 
-from calliope.tables import Story, StoryFrame
 from calliope.storage.vector_manager import semantic_search
+from calliope.tables import Story, StoryFrame
 from calliope.utils.pagination import Pagination
-
 
 router = APIRouter()
 templates = Jinja2Templates(directory="calliope/templates")
@@ -51,7 +50,7 @@ async def thoth_root(
         "show_metadata": meta,
         "pagination": pagination,
     }
-    return cast(HTMLResponse, templates.TemplateResponse("thoth.html", context))
+    return cast(HTMLResponse, templates.TemplateResponse(request, "thoth.html", context))
 
 
 @router.get("/thoth/story/{story_cuid}", response_class=HTMLResponse)
@@ -92,7 +91,9 @@ async def thoth_story(
         "show_metadata": meta,
         "pagination": pagination,
     }
-    return cast(HTMLResponse, templates.TemplateResponse("thoth_story.html", context))
+    return cast(
+        HTMLResponse, templates.TemplateResponse(request, "thoth_story.html", context)
+    )
 
 
 @router.get("/thoth/search/", response_class=HTMLResponse)
@@ -142,4 +143,6 @@ async def thoth_search(
         "show_metadata": meta,
         "story_page_size": PAGE_SIZE,
     }
-    return cast(HTMLResponse, templates.TemplateResponse("thoth_search.html", context))
+    return cast(
+        HTMLResponse, templates.TemplateResponse(request, "thoth_search.html", context)
+    )


### PR DESCRIPTION
Thoth 500s on every page:
```
GET /thoth/?meta=1 → 500 Internal Server Error
TypeError: unhashable type: 'dict'
  thoth.py:54 → templates.TemplateResponse("thoth.html", context)
  → starlette templating get_template → jinja2 cache __getitem__
```

## Root cause
The Thoth routes used the old Starlette signature `TemplateResponse(name, context)`. Newer Starlette (pulled in by the #82 dependency upgrade) changed it to `TemplateResponse(request, name, context)`. With the old call, the `context` **dict** was taken as the template name and used as a jinja cache key → `unhashable type: 'dict'`. All three Thoth routes were affected, so the whole tool was down.

## Fix
Pass `request` first in all three calls (`thoth_root`, `thoth_story`, `thoth_search`).

## Testing
- Reproduced the 500 against production and pulled the traceback from Cloud Run logs.
- Verified locally: `templates.TemplateResponse(request, "thoth.html", context)` renders `thoth.html` → 200 with real HTML (previously raised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)